### PR TITLE
Changing ROOT_DIR

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -12,4 +12,4 @@ except LookupError:
     nltk.download("wordnet")
     nltk.download("omw-1.4")
 
-ROOT_DIR = pathlib.Path(__file__).resolve().parent
+ROOT_DIR = pathlib.Path(__file__).resolve().parent.parent


### PR DESCRIPTION
ROOT_DIR initially pointed to `src` rather than the package root.